### PR TITLE
Prepare pipeline for serverless resource destruction.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
-  deploy-lambda:
+  deploy-or-remove-lambda:
     description: "Deploys API via Serverless"
     parameters:
       stage:
@@ -76,10 +76,15 @@ commands:
           name: Install serverless CLI
           command: npm i -g serverless
       - run:
-          name: Deploy lambda
+          name: Deploy or remove lambda
           command: |
             cd ./ProjectFinderApi/
-            sls deploy --stage <<parameters.stage>> --account <<parameters.aws-account>> --conceal
+            if [ "<<parameters.stage>>" = "environment" ]
+            then
+              sls remove --stage <<parameters.stage>> --account <<parameters.aws-account>> --verbose
+            else
+              sls deploy --stage <<parameters.stage>> --account <<parameters.aws-account>> --conceal
+            fi
 
 jobs:
   assume-role-development:
@@ -105,13 +110,13 @@ jobs:
   deploy-to-development:
     executor: docker-dotnet
     steps:
-      - deploy-lambda:
+      - deploy-or-remove-lambda:
           stage: "development"
           aws-account: $AWS_ACCOUNT_DEVELOPMENT
   deploy-to-staging:
     executor: docker-dotnet
     steps:
-      - deploy-lambda:
+      - deploy-or-remove-lambda:
           stage: "staging"
           aws-account: $AWS_ACCOUNT_STAGING
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_18.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,6 @@ commands:
           name: Install serverless CLI
           command: npm i -g serverless
       - run:
-          name: Build lambda
-          command: |
-            cd ./ProjectFinderApi/
-            chmod +x ./build.sh
-            ./build.sh
-      - run:
           name: Deploy lambda
           command: |
             cd ./ProjectFinderApi/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Deploy or remove lambda
           command: |


### PR DESCRIPTION
# What:
 - Bump the pipeline's node.js version to v18.
 - Cap the serverless framework to major v3.
 - Prepare the pipeline for destroying serverless resources by specified environment.

# Why:
 - The previously specified version was deprecated & refuses to work. A higher version gives 80sec wait timer. A further higher version gives a massive warning message bloating the logs. So v18 is the minimum good enough version.
 - The serverless v4 has changed their licensing model to require a paid license.
 - The serverless resources will be the first ones to go to avoid any potential dependency conflicts when destroying terraform resources.

# Notes:
 - Again, there's no `feature` workflow pipeline. That will get addressed 2 PRs from this one.
 - Once this PR is merged, the pipeline will fail due to expired SSH key.
 - The `development` branch is skipped in this merged as the next PR will retire that branch.