### PR TITLE
Retire `development` branch by merging `development` and `staging` workflows.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,9 @@ jobs:
           aws-account: $AWS_ACCOUNT_STAGING
 
 workflows:
-  deploy-development:
-    jobs:
+
+  deploy-or-remove-development-and-staging:
+      jobs:
       - assume-role-development:
           context: api-assume-role-development-context
           filters:
@@ -155,11 +156,11 @@ workflows:
           filters:
             branches:
               only: development
-
-  check-and-deploy-staging:
-      jobs:
       - assume-role-staging:
           context: api-assume-role-staging-context
+          requires:
+            - deploy-to-development
+            - terraform-init-and-apply-to-development
           filters:
              branches:
                only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
 
 workflows:
   deploy-or-remove-development-and-staging:
-      jobs:
+    jobs:
       - assume-role-development:
           context: api-assume-role-development-context
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
   deploy-or-remove-lambda:
-    description: "Deploys API via Serverless"
+    description: "Deploys or Removes API via Serverless"
     parameters:
       stage:
         type: string
@@ -121,7 +121,6 @@ jobs:
           aws-account: $AWS_ACCOUNT_STAGING
 
 workflows:
-
   deploy-or-remove-development-and-staging:
       jobs:
       - assume-role-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,34 +128,34 @@ workflows:
           context: api-assume-role-development-context
           filters:
             branches:
-              only: development
+              only: master
       - permit-development-terraform-release:
           type: approval
           requires:
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
       - terraform-init-and-apply-to-development:
           requires:
             - permit-development-terraform-release
           filters:
             branches:
-              only: development
+              only: master
       - permit-development-serverless-release:
           type: approval
           requires:
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
       - deploy-to-development:
           context: api-assume-role-development-context
           requires:
             - permit-development-serverless-release
           filters:
             branches:
-              only: development
+              only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:


### PR DESCRIPTION
# What:
 - Combine the `development` and `staging` workflows into a single workflow.
 - Make the `development` workflow trigger on `master` branch rather than `development`.
 - Tweak workflow and command names for clarity.

# Why:
 - To avoid needing to raise duplicate PRs for going from `development` to `staging` when the only goal is cloud resource decommissioning.

# Notes:
 - Still no `feature` workflow - will get addressed in the next PR.
 - Pipeline will fail after merge due to expired SSH key.