### PR TITLE
Add `feature` branch workflow with terraform preview steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,21 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
+  terraform-preview:
+    description: "Previews terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: terraform preview
   deploy-or-remove-lambda:
     description: "Deploys or Removes API via Serverless"
     parameters:
@@ -106,6 +121,16 @@ jobs:
     executor: docker-terraform
     steps:
       - terraform-init-then-apply:
+          environment: "staging"
+  terraform-preview-development:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "development"
+  terraform-preview-staging:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
           environment: "staging"
   deploy-to-development:
     executor: docker-dotnet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,18 @@ jobs:
           aws-account: $AWS_ACCOUNT_STAGING
 
 workflows:
+  feature-preview-tf:
+    jobs:
+      - assume-role-development:
+          context: api-assume-role-development-context
+          filters:
+            branches:
+              ignore: master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          filters:
+             branches:
+               ignore: master
   deploy-or-remove-development-and-staging:
     jobs:
       - assume-role-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,11 +153,23 @@ workflows:
           filters:
             branches:
               ignore: master
+      - terraform-preview-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              ignore: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           filters:
              branches:
                ignore: master
+      - terraform-preview-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              ignore: master
   deploy-or-remove-development-and-staging:
     jobs:
       - assume-role-development:


### PR DESCRIPTION
# What:
 - Added terraform preview command and job definitions.
 - Added a `feature` branch workflow.
 - Hooked the terraform previews into the `feature` workflow.

# Why:
 - To easier observe and debug terraform related steps and resource decommissioning.

# Notes:
 - The terraform previews are showing as failing as typical due to the renaming of `DevelopmentAPIs` and `StagingAPIs` VPCs that has happened some time ago after this configuration was last deployed.
