### PR TITLE
Retire the `DevelopmentAPIs` environment serverless resources. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
           name: Deploy or remove lambda
           command: |
             cd ./ProjectFinderApi/
-            if [ "<<parameters.stage>>" = "environment" ]
+            if [ "<<parameters.stage>>" = "development" ]
             then
               sls remove --stage <<parameters.stage>> --account <<parameters.aws-account>> --verbose
             else


### PR DESCRIPTION
# What:
 - Make the pipeline trigger the removal of serverless resources within the `DevelopmentAPIs` AWS account.

# Why:
 - The database this API consumes is about to become decommissioned, so the the application is no longer needed.

# Notes:
 - Again, the terraform preview shows as failing due to the renamed VPC. This is irrelevant when it comes decommissioning work.