### PR TITLE
Remove deprecated serverless framework options.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,9 @@ commands:
             cd ./ProjectFinderApi/
             if [ "<<parameters.stage>>" = "development" ]
             then
-              sls remove --stage <<parameters.stage>> --account <<parameters.aws-account>> --verbose
+              sls remove --stage <<parameters.stage>> --verbose
             else
-              sls deploy --stage <<parameters.stage>> --account <<parameters.aws-account>> --conceal
+              sls deploy --stage <<parameters.stage>> --conceal
             fi
 
 jobs:


### PR DESCRIPTION
# What:
 - Fix serverless by removing the no longer supported '--account' options.

# Why:
 - To unblock the pipeline to trigger the resource removal started by PR #25 .

# Notes:
 - Preview is failing due to renamed VPCs - irrelevant for decommissioning.