### PR TITLE
Remove `DevelopmentAPIs` terraform managed resources.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -11,8 +11,6 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
 
 terraform {
   backend "s3" {
@@ -22,24 +20,3 @@ terraform {
     key     = "services/project-finder-api/state"
   }
 }
-
-data "aws_vpc" "development_vpc" {
-  tags = {
-    Name = "vpc-development-apis-development"
-  }
-}
-data "aws_subnet_ids" "development" {
-  vpc_id = data.aws_vpc.development_vpc.id
-  filter {
-    name   = "tag:environment"
-    values = ["development"]
-  }
-}
-
-data "aws_ssm_parameter" "project_finder_postgres_db_password" {
-   name = "/project-finder-api/development/postgres-password"
- }
-
- data "aws_ssm_parameter" "project_finder_postgres_username" {
-   name = "/project-finder-api/development/postgres-username"
- }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -43,25 +43,3 @@ data "aws_ssm_parameter" "project_finder_postgres_db_password" {
  data "aws_ssm_parameter" "project_finder_postgres_username" {
    name = "/project-finder-api/development/postgres-username"
  }
-
-module "postgres_db_development" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "development"
-  vpc_id = data.aws_vpc.development_vpc.id
-  db_identifier = "project-finder"
-  db_name = "project_finder"
-  db_port  = 5602
-  subnet_ids = data.aws_subnet_ids.development.ids
-  db_engine = "postgres"
-  db_engine_version = "13.3"
-  db_instance_class = "db.t3.micro"
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  db_username = data.aws_ssm_parameter.project_finder_postgres_username.value
-  db_password = data.aws_ssm_parameter.project_finder_postgres_db_password.value
-  storage_encrypted = true
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "project finder api"
-}
-


### PR DESCRIPTION
# What:
 - Remove the `project-finder-db-development` AWS RDS postgres database instance on the `DevelopmentAPIs` account.

# Why:
 - The database was never in use and so can be decommissioned.

# Notes:
 - No database snapshot is created because this was a test project that also never had a live environment, so there's no valuable data to back up.
 - The terraform preview is failing for staging due to renamed VPC as can be evident by how this issue got fixed for the development preview with this PR.