### PR TITLE
Retire serverless resources on `StagingAPIs` environment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
           name: Deploy or remove lambda
           command: |
             cd ./ProjectFinderApi/
-            if [ "<<parameters.stage>>" = "environement" ]
+            if [ "<<parameters.stage>>" = "staging" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else


### PR DESCRIPTION
# What:
 - Make the pipeline trigger the serverless resource deletion on `StagingAPIs` environment.

# Why:
 - The environment is not used and the project was a prototype anyway.

# Notes:
 - TF staging preview fails, but that will get addressed in the next PR.