### PR TITLE
Retire `StagingAPIs` terraform resources.

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -43,24 +43,3 @@ data "aws_ssm_parameter" "project_finder_postgres_db_password" {
  data "aws_ssm_parameter" "project_finder_postgres_username" {
    name = "/project-finder-api/staging/postgres-username"
  }
-
-module "postgres_db_staging" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "staging"
-  vpc_id = data.aws_vpc.staging_vpc.id
-  db_identifier = "project-finder"
-  db_name = "project_finder"
-  db_port  = 5602
-  subnet_ids = data.aws_subnet_ids.staging.ids
-  db_engine = "postgres"
-  db_engine_version = "13.3"
-  db_instance_class = "db.t3.micro"
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  db_username = data.aws_ssm_parameter.project_finder_postgres_username.value
-  db_password = data.aws_ssm_parameter.project_finder_postgres_db_password.value
-  storage_encrypted = true
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "project finder api"
-}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -11,8 +11,6 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
 
 terraform {
   backend "s3" {
@@ -22,24 +20,3 @@ terraform {
     key     = "services/project-finder-api/state"
   }
 }
-
-data "aws_vpc" "staging_vpc" {
-  tags = {
-    Name = "vpc-staging-apis-staging"
-  }
-}
-data "aws_subnet_ids" "staging" {
-  vpc_id = data.aws_vpc.staging_vpc.id
-  filter {
-    name   = "tag:Type"
-    values = ["private"]
-  }
-}
-
-data "aws_ssm_parameter" "project_finder_postgres_db_password" {
-   name = "/project-finder-api/staging/postgres-password"
- }
-
- data "aws_ssm_parameter" "project_finder_postgres_username" {
-   name = "/project-finder-api/staging/postgres-username"
- }


### PR DESCRIPTION
# What:
 - Retire the `project-finder-db-staging` AWS RDS postgres database instance.

# Why:
 - It was never used as the project was a prototype.

# Notes:
 - No snapshot is needed as there's no data of value.
