### PR TITLE
.NET 3.1 to 8 upgrade

### DIFF
--- a/ProjectFinderApi.Tests/Dockerfile
+++ b/ProjectFinderApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/ProjectFinderApi.Tests/Dockerfile
+++ b/ProjectFinderApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/ProjectFinderApi.Tests/ProjectFinderApi.Tests.csproj
+++ b/ProjectFinderApi.Tests/ProjectFinderApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/ProjectFinderApi.Tests/ProjectFinderApi.Tests.csproj
+++ b/ProjectFinderApi.Tests/ProjectFinderApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/ProjectFinderApi.Tests/V1/Controllers/BaseControllerTests.cs
+++ b/ProjectFinderApi.Tests/V1/Controllers/BaseControllerTests.cs
@@ -40,7 +40,7 @@ namespace ProjectFinderApi.Tests.V1.Controllers
         public void GetCorrelationShouldReturnCorrelationIdWhenExists()
         {
             // Arrange
-            _stubHttpContext.Request.Headers.Add(Constants.CorrelationId, "123");
+            _stubHttpContext.Request.Headers.Append(Constants.CorrelationId, "123");
 
             // Act
             var result = _sut.GetCorrelationId();

--- a/ProjectFinderApi.Tests/V1/Infrastructure/CorrelationMiddlewareTests.cs
+++ b/ProjectFinderApi.Tests/V1/Infrastructure/CorrelationMiddlewareTests.cs
@@ -25,7 +25,7 @@ namespace ProjectFinderApi.Tests.V1.Infrastructure
             var httpContext = new DefaultHttpContext();
             var headerValue = "123";
 
-            httpContext.HttpContext.Request.Headers.Add(Constants.CorrelationId, headerValue);
+            httpContext.HttpContext.Request.Headers.Append(Constants.CorrelationId, headerValue);
 
             // Act
             await _sut.InvokeAsync(httpContext).ConfigureAwait(false);

--- a/ProjectFinderApi/Dockerfile
+++ b/ProjectFinderApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 WORKDIR /app
 

--- a/ProjectFinderApi/Dockerfile
+++ b/ProjectFinderApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 WORKDIR /app
 

--- a/ProjectFinderApi/ProjectFinderApi.csproj
+++ b/ProjectFinderApi/ProjectFinderApi.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/ProjectFinderApi/ProjectFinderApi.csproj
+++ b/ProjectFinderApi/ProjectFinderApi.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,27 +9,27 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="5.1.1"/>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.4.36"/>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101"/>
-    <PackageReference Include="AWSXRayRecorder.Core" Version="2.10.0"/>
-    <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.2"/>
-    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2"/>
-    <PackageReference Include="AWSXRayRecorder.Handlers.EntityFramework" Version="1.1.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7"/>
-    <PackageReference Include="FluentValidation" Version="10.3.0"/>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.4.36" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
+    <PackageReference Include="AWSXRayRecorder.Core" Version="2.10.0" />
+    <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.2" />
+    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
+    <PackageReference Include="AWSXRayRecorder.Handlers.EntityFramework" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />
+    <PackageReference Include="FluentValidation" Version="10.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="terraform\"/>
+    <Folder Include="terraform\" />
   </ItemGroup>
 </Project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
   project-finder-api:
     image: project-finder-api


### PR DESCRIPTION
We're doing this in the Community of Practice as a mob programming exercise.

This PR contains two commits (poorly named and commented because we were on a group call).

The first upgrades to .NET 6, the second to .NET 8.

There are also a handful of changes required to fix compiler errors for each upgrade.